### PR TITLE
"履歴の削除機能と非同期UI更新の修正"

### DIFF
--- a/async_ui_update_debug_summary.txt
+++ b/async_ui_update_debug_summary.txt
@@ -1,0 +1,24 @@
+## 非同期UI更新の問題解決までの流れ
+
+### 問題の概要
+履歴の削除ボタンを押しても、画面が自動的に更新されず、手動でリロードしないと変更が反映されない問題が発生しました。バックエンドでの削除処理は成功していました。
+
+### 解決までのステップ
+
+1.  **最初の試み: `setHistory` による直接的なステート更新**
+    - **目的:** 削除成功後、`fetchHistory()` を呼び出して履歴全体を再フェッチするのではなく、`setHistory` を使用してフロントエンドの `history` ステートから直接該当エントリを削除することで、非同期更新を実現しようとしました。
+    - **変更内容:** `frontend/src/App.jsx` の `handleDelete` 関数内で、`fetchHistory()` の代わりに `setHistory(prevHistory => prevHistory.filter(entry => entry.id !== id))` を使用しました。
+    - **結果:** 削除ボタンを押しても画面が更新されませんでした。コンソールを確認すると、`ReferenceError: setHistory is not defined` および `ReferenceError: setError is not defined` というエラーが発生していました。
+
+2.  **エラーの原因特定と修正: スコープの問題**
+    - **原因:** `setHistory` と `setError` が `handleDelete` 関数からアクセスできないスコープにありました。これは、`handleDelete` 関数が `App` コンポーネントの `return` ステートメントの後に定義されていたためです。
+    - **変更内容:** `handleDelete` 関数を `App` コンポーネントの内部、`return` ステートメントの直前に移動しました。
+    - **結果:** `ReferenceError` は解消されましたが、新たに `[plugin:vite:react-babel] Identifier 'filteredHistory' has already been declared` というエラーが発生しました。
+
+3.  **エラーの原因特定と修正: 重複する変数宣言**
+    - **原因:** `handleDelete` 関数を移動した際に、`filteredHistory` 変数の宣言が `App.jsx` 内で二重になっていました。
+    - **変更内容:** 重複していた `filteredHistory` の宣言（58行目から始まる部分）を削除しました。
+    - **結果:** エラーが解消され、削除ボタンを押すと履歴が非同期で画面に反映されるようになりました。
+
+### 結論
+非同期UI更新の問題は、主にJavaScriptのスコープの問題と、それに続くコードの重複宣言によって引き起こされていました。`handleDelete` 関数を適切なスコープに配置し、重複する変数宣言を解消することで、期待通りの非同期更新が実現されました。

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,10 @@ function App() {
   const [uniqueSites, setUniqueSites] = useState([]);
 
   useEffect(() => {
+    fetchHistory();
+  }, []);
+
+  const fetchHistory = () => {
     fetch('http://127.0.0.1:3000/api/history')
       .then(response => {
         if (!response.ok) {
@@ -29,7 +33,7 @@ function App() {
         setError(error);
         setLoading(false);
       });
-  }, []);
+  };
 
   if (loading) {
     return <div>Loading...</div>;
@@ -50,6 +54,33 @@ function App() {
 
     return matchesSite && matchesStartDate && matchesEndDate;
   });
+
+  const handleDelete = async (id) => {
+    const numericId = Number(id); // Ensure id is a number
+    console.log('Attempting to delete history entry with ID:', numericId);
+    try {
+      const response = await fetch(`http://127.0.0.1:3000/api/history/${numericId}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to delete history entry: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+      console.log('Deletion successful for ID:', numericId);
+      setHistory(prevHistory => {
+        const newHistory = prevHistory.filter(entry => {
+          console.log(`Comparing entry.id (${entry.id}) with numericId (${numericId})`);
+          return entry.id !== numericId;
+        });
+        console.log('Previous history:', prevHistory);
+        console.log('New history after filter:', newHistory);
+        return newHistory;
+      });
+    } catch (error) {
+      console.error('Error deleting history entry:', error);
+      setError(error);
+    }
+  };
 
   return (
     <div className="App">
@@ -85,6 +116,7 @@ function App() {
               <th>Title</th>
               <th>URL</th>
               <th>Timestamp</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -93,6 +125,9 @@ function App() {
                 <td>{entry.title}</td>
                 <td><a href={entry.url} target="_blank" rel="noopener noreferrer">{entry.url}</a></td>
                 <td>{new Date(entry.timestamp).toLocaleString()}</td>
+                <td>
+                  <button onClick={() => handleDelete(entry.id)}>Delete</button>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ async fn main() {
         .route("/api/is_monitored", get(is_monitored))
         .route("/api/sites", get(get_sites).post(add_site)) // New endpoints for sites
         .route("/api/sites/:id", delete(delete_site))      // New endpoint for deleting a site
+        .route("/api/history/:id", delete(delete_history_entry)) // New endpoint for deleting a history entry
         .with_state(db_state)
         .layer(cors);
 
@@ -207,4 +208,23 @@ async fn log_entry(State(db): State<DbState>, Json(payload): Json<LogRequest>) {
         &[&payload.url, &payload.title, &Utc::now().to_rfc3339()],
     ).unwrap();
     println!("Logged: url={}, title={}", payload.url, payload.title);
+}
+
+async fn delete_history_entry(State(db): State<DbState>, Path(id): Path<i32>) -> impl IntoResponse {
+    println!("Attempting to delete history entry with ID: {}", id);
+    let conn = db.lock().unwrap();
+    match conn.execute("DELETE FROM history WHERE id = ?", [id]) {
+        Ok(rows_affected) if rows_affected > 0 => {
+            println!("Successfully deleted history entry with ID: {}", id);
+            (StatusCode::OK, "History entry deleted successfully".to_string())
+        },
+        Ok(_) => {
+            println!("History entry with ID: {} not found", id);
+            (StatusCode::NOT_FOUND, "History entry not found".to_string())
+        },
+        Err(e) => {
+            eprintln!("Failed to delete history entry with ID: {}. Error: {}", id, e);
+            (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to delete history entry: {}", e))
+        },
+    }
 }


### PR DESCRIPTION
## 機能追加: 履歴の削除機能と非同期UI更新の修正

### 目的
ユーザーが個々のWebマンガ閲覧履歴エントリを削除できるようにし、削除操作が非同期でUIに即座に反映されるようにすることで、履歴管理の利便性を向上させます。

### 変更点
- **バックエンド (`src/main.rs`):**
    - 履歴エントリをIDで削除するための新しいAPIエンドポイント `DELETE /api/history/:id` を追加しました。
    - `delete_history_entry` 関数を実装し、指定されたIDの履歴をデータベースから削除します。
    - デバッグのために、削除処理の開始、成功、失敗時にログを出力するようにしました。

- **フロントエンド (`frontend/src/App.jsx`):**
    - 各履歴エントリに「Delete」ボタンを追加しました。
    - `handleDelete` 関数を実装し、ボタンクリック時にバックエンドの削除APIを呼び出します。
    - 削除が成功した場合、`setHistory` を使用してReactのステートを直接更新し、該当するエントリを履歴リストから削除することで、UIが非同期で即座に更新されるようにしました。
    - `handleDelete` 関数が `App` コンポーネントの適切なスコープ内に配置されるように修正しました。
    - `filteredHistory` 変数の重複宣言を削除し、構文エラーを解消しました。

### テストの方法
1.  **バックエンドの起動:**
    `web_manga_checker` プロジェクトのルートディレクトリで、以下のコマンドを実行してバックエンドサーバーを起動します。
    ```bash
    cargo run
    ```
2.  **フロントエンド開発サーバーの起動:**
    別のターミナルで `frontend` ディレクトリに移動し、以下のコマンドを実行してフロントエンド開発サーバーを起動します。
    ```bash
    cd frontend
    npm run dev
    ```
3.  **ブラウザでのアクセス:**
    ブラウザでフロントエンドのURL（通常は `http://localhost:5173` など）にアクセスします。
4.  **履歴ページの確認:**
    アプリケーションの履歴表示セクションに移動し、履歴エントリが表示されていることを確認します。
5.  **削除機能の操作:**
    - 任意の履歴エントリの横にある「Delete」ボタンをクリックします。
    - 複数の履歴エントリがある場合は、いくつか削除を試します。
    - フィルタリング機能と組み合わせて、フィルタリングされた状態で削除が正しく行われるか確認します。

### テストの成功基準
- 各履歴エントリの横に「Delete」ボタンが表示されること。
- 「Delete」ボタンをクリックすると、確認ダイアログなしで、クリックした履歴エントリが画面から即座に消えること。
- ページをリロードしなくても、削除されたエントリが履歴リストから消えていること。
- バックエンドのコンソールに、削除操作が成功したことを示すログ（例: `Successfully deleted history entry with ID: ...`）が表示されること。
- 存在しないIDの削除を試みた場合、バックエンドのログに「History entry not found」が表示され、フロントエンドでエラーが表示されること（任意）。
